### PR TITLE
main.go #3 修正

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,5 @@
+module pokemon-api
+
+go 1.24.0
+
+require github.com/gorilla/mux v1.8.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,7 +1,75 @@
 package main
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// Sprites はポケモンの画像情報を表します。
+type Sprites struct {
+	FrontDefault string `json:"front_default"`
+}
+
+// PokemonResponse はポケモンAPIのレスポンスを表します。
+type PokemonResponse struct {
+	ID      int     `json:"id"`
+	Name    string  `json:"name"`
+	Sprites Sprites `json:"sprites"`
+}
+
+// Pokemon はフロントエンド向けのデータ構造
+type Pokemon struct {
+	ID    int    `json:"id"`
+	Name  string `json:"name"`
+	Image string `json:"image"`
+}
+
+// getPokemonHandler は指定したポケモンの情報を取得するエンドポイント
+func getPokemonHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	// PokeAPI からデータを取得するためのURLを作成して変数に格納する
+	apiURL := fmt.Sprintf("https://pokeapi.co/api/v2/pokemon/%s", id)
+	// レスポンスとエラーメッセージを受け取る
+	resp, err := http.Get(apiURL)
+	if err != nil {
+		http.Error(w, "外部APIからのデータ取得に失敗しました", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		http.Error(w, "ポケモンが見つかりません", http.StatusNotFound)
+		return
+	}
+
+	// レスポンスをパース
+	var pokeResponse PokemonResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pokeResponse); err != nil {
+		http.Error(w, "データの解析に失敗しました", http.StatusInternalServerError)
+		return
+	}
+
+	// フロントエンド向けのデータ整形
+	pokemon := Pokemon{
+		ID:    pokeResponse.ID,
+		Name:  pokeResponse.Name,
+		Image: pokeResponse.Sprites.FrontDefault,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(pokemon)
+}
 
 func main() {
-	fmt.Println("Hello, World!")
+	r := mux.NewRouter()
+	r.HandleFunc("/pokemon/{id}", getPokemonHandler).Methods("GET")
+
+	fmt.Println("サーバー起動: http://localhost:8080")
+	log.Fatal(http.ListenAndServe(":8080", r))
 }


### PR DESCRIPTION
## PR 概要
Pokémon API からポケモンの番号・名前・画像を取得する Go 言語の API サーバーを実装しました。
フロントエンドが利用しやすい形式でデータを提供するためのエンドポイントを作成しました。
動作確認として、`localhost:8080/pokemon/1` にアクセスし、Bulbasaur の情報が正しく取得できることを確認しました。

## 変更内容
- Pokémon API からデータを取得し、ID、名前、画像 URL を抽出する API サーバーを Go 言語で実装
- `gorilla/mux` を使用してルーティングを設定
- 外部 API からデータを取得し、レスポンスをフロントエンド向けに整形
- エラーハンドリングを実装し、安定したデータ取得を保証
- サーバーのエンドポイント `/pokemon/{id}` を作成
- 動作確認として、`localhost:8080/pokemon/1` へアクセスし、正しい JSON データが取得できることを確認

### リクエスト・レスポンスの例

#### リクエスト
```bash
GET /pokemon/1 HTTP/1.1
Host: localhost:8080
```

#### レスポンス
```json
{
    "id": 1,
    "name": "bulbasaur",
    "image": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png"
}
```

## 動作確認方法
1. サーバーを起動:
   ```bash
   go run main.go
   ```
2. ブラウザまたは `curl` でエンドポイントにアクセス:
   ```bash
   curl -X GET http://localhost:8080/pokemon/1
   ```
3. 正しくデータが取得できることを確認（確認済み）

## 確認事項
- [x] コードのフォーマットチェック済み (`gofmt` 実行済み)
- [x] API の動作確認済み（`localhost:8080/pokemon/1` にて Bulbasaur のデータ取得確認）