### PR TITLE
全ポケモンの名前と番号、画像のURLを取得するエンドポイントを実装 #7

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+
+	"github.com/gorilla/mux"
+)
+
+// getPokemonHandler は指定したポケモンの情報を取得するエンドポイント
+func getPokemonHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	apiURL := fmt.Sprintf("https://pokeapi.co/api/v2/pokemon/%s", id)
+	resp, err := http.Get(apiURL)
+	if err != nil {
+		http.Error(w, "外部APIからのデータ取得に失敗しました", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		http.Error(w, "ポケモンが見つかりません", http.StatusNotFound)
+		return
+	}
+
+	var pokeResponse PokemonResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pokeResponse); err != nil {
+		http.Error(w, "データの解析に失敗しました", http.StatusInternalServerError)
+		return
+	}
+
+	pokemon := Pokemon{
+		ID:    pokeResponse.ID,
+		Name:  pokeResponse.Name,
+		Image: pokeResponse.Sprites.FrontDefault,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(pokemon)
+}
+
+// getPokemonsHandler は、すべてのポケモンの情報を取得するエンドポイント
+func getPokemonsHandler(w http.ResponseWriter, r *http.Request) {
+	apiURL := "https://pokeapi.co/api/v2/pokemon?limit=2000"
+	resp, err := http.Get(apiURL)
+	if err != nil {
+		http.Error(w, "外部APIからのリスト取得に失敗しました", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		http.Error(w, "ポケモンリストが見つかりません", http.StatusNotFound)
+		return
+	}
+
+	var listResp PokemonListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+		http.Error(w, "リストデータの解析に失敗しました", http.StatusInternalServerError)
+		return
+	}
+
+	var pokemons []Pokemon
+	re := regexp.MustCompile(`/pokemon/(\d+)/?$`)
+
+	for _, result := range listResp.Results {
+		matches := re.FindStringSubmatch(result.URL)
+		if len(matches) < 2 {
+			continue
+		}
+
+		id, err := strconv.Atoi(matches[1])
+		if err != nil {
+			continue
+		}
+
+		imageURL := fmt.Sprintf("https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/%d.png", id)
+		pokemons = append(pokemons, Pokemon{
+			ID:    id,
+			Name:  result.Name,
+			Image: imageURL,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(pokemons)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,127 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
-	"regexp"
-	"strconv"
 
 	"github.com/gorilla/mux"
 )
-
-// Sprites はポケモンの画像情報を表します。
-type Sprites struct {
-	FrontDefault string `json:"front_default"`
-}
-
-// PokemonResponse はポケモンAPIのレスポンスを表します。
-type PokemonResponse struct {
-	ID      int     `json:"id"`
-	Name    string  `json:"name"`
-	Sprites Sprites `json:"sprites"`
-}
-
-// Pokemon はフロントエンド向けのデータ構造（単体用・複数用で共通利用）。
-type Pokemon struct {
-	ID    int    `json:"id"`
-	Name  string `json:"name"`
-	Image string `json:"image"`
-}
-
-// PokemonListResponse は /pokemon?limit=... 取得時のレスポンスを表します。
-type PokemonListResponse struct {
-	Count    int    `json:"count"`
-	Next     string `json:"next"`
-	Previous string `json:"previous"`
-	Results  []struct {
-		Name string `json:"name"`
-		URL  string `json:"url"`
-	} `json:"results"`
-}
-
-// getPokemonHandler は指定したポケモンの情報を取得するエンドポイント
-func getPokemonHandler(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	id := vars["id"]
-
-	// PokeAPI からデータを取得するためのURLを作成
-	apiURL := fmt.Sprintf("https://pokeapi.co/api/v2/pokemon/%s", id)
-	resp, err := http.Get(apiURL)
-	if err != nil {
-		http.Error(w, "外部APIからのデータ取得に失敗しました", http.StatusInternalServerError)
-		return
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		http.Error(w, "ポケモンが見つかりません", http.StatusNotFound)
-		return
-	}
-
-	var pokeResponse PokemonResponse
-	if err := json.NewDecoder(resp.Body).Decode(&pokeResponse); err != nil {
-		http.Error(w, "データの解析に失敗しました", http.StatusInternalServerError)
-		return
-	}
-
-	pokemon := Pokemon{
-		ID:    pokeResponse.ID,
-		Name:  pokeResponse.Name,
-		Image: pokeResponse.Sprites.FrontDefault,
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(pokemon)
-}
-
-// getPokemonsHandler は、すべてのポケモンの情報を取得するエンドポイント
-func getPokemonsHandler(w http.ResponseWriter, r *http.Request) {
-	apiURL := "https://pokeapi.co/api/v2/pokemon?limit=2000"
-	resp, err := http.Get(apiURL)
-	if err != nil {
-		http.Error(w, "外部APIからのリスト取得に失敗しました", http.StatusInternalServerError)
-		return
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		http.Error(w, "ポケモンリストが見つかりません", http.StatusNotFound)
-		return
-	}
-
-	var listResp PokemonListResponse
-	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
-		http.Error(w, "リストデータの解析に失敗しました", http.StatusInternalServerError)
-		return
-	}
-
-	var pokemons []Pokemon
-	re := regexp.MustCompile(`/pokemon/(\d+)/?$`)
-
-	for _, result := range listResp.Results {
-		matches := re.FindStringSubmatch(result.URL)
-		if len(matches) < 2 {
-			continue
-		}
-
-		id, err := strconv.Atoi(matches[1])
-		if err != nil {
-			continue
-		}
-
-		imageURL := fmt.Sprintf("https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/%d.png", id)
-		pokemons = append(pokemons, Pokemon{
-			ID:    id,
-			Name:  result.Name,
-			Image: imageURL,
-		})
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(pokemons)
-}
 
 func main() {
 	r := mux.NewRouter()

--- a/backend/main.go
+++ b/backend/main.go
@@ -5,70 +5,91 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
+	"strconv"
 
 	"github.com/gorilla/mux"
 )
 
-// Sprites はポケモンの画像情報を表します。
-type Sprites struct {
-	FrontDefault string `json:"front_default"`
-}
-
-// PokemonResponse はポケモンAPIのレスポンスを表します。
-type PokemonResponse struct {
-	ID      int     `json:"id"`
-	Name    string  `json:"name"`
-	Sprites Sprites `json:"sprites"`
-}
-
-// Pokemon はフロントエンド向けのデータ構造
+// Pokemon はフロントエンド向けのデータ構造（単体用・複数用で共通利用）。
 type Pokemon struct {
 	ID    int    `json:"id"`
 	Name  string `json:"name"`
 	Image string `json:"image"`
 }
 
-// getPokemonHandler は指定したポケモンの情報を取得するエンドポイント
-func getPokemonHandler(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	id := vars["id"]
+// PokemonListResponse は /pokemon?limit=... 取得時のレスポンスを表します。
+type PokemonListResponse struct {
+	Count    int    `json:"count"`
+	Next     string `json:"next"`
+	Previous string `json:"previous"`
+	Results  []struct {
+		Name string `json:"name"`
+		URL  string `json:"url"`
+	} `json:"results"`
+}
 
-	// PokeAPI からデータを取得するためのURLを作成して変数に格納する
-	apiURL := fmt.Sprintf("https://pokeapi.co/api/v2/pokemon/%s", id)
-	// レスポンスとエラーメッセージを受け取る
+// getPokemonsHandler は、すべてのポケモンの情報を取得するエンドポイント
+func getPokemonsHandler(w http.ResponseWriter, r *http.Request) {
+	// すべてのポケモンを取得するため limit を大きな値に設定
+	apiURL := "https://pokeapi.co/api/v2/pokemon?limit=2000"
 	resp, err := http.Get(apiURL)
 	if err != nil {
-		http.Error(w, "外部APIからのデータ取得に失敗しました", http.StatusInternalServerError)
+		http.Error(w, "外部APIからのリスト取得に失敗しました", http.StatusInternalServerError)
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		http.Error(w, "ポケモンが見つかりません", http.StatusNotFound)
+		http.Error(w, "ポケモンリストが見つかりません", http.StatusNotFound)
 		return
 	}
 
-	// レスポンスをパース
-	var pokeResponse PokemonResponse
-	if err := json.NewDecoder(resp.Body).Decode(&pokeResponse); err != nil {
-		http.Error(w, "データの解析に失敗しました", http.StatusInternalServerError)
+	// リスト用レスポンスをパース
+	var listResp PokemonListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+		http.Error(w, "リストデータの解析に失敗しました", http.StatusInternalServerError)
 		return
 	}
 
-	// フロントエンド向けのデータ整形
-	pokemon := Pokemon{
-		ID:    pokeResponse.ID,
-		Name:  pokeResponse.Name,
-		Image: pokeResponse.Sprites.FrontDefault,
+	// 取得した results の配列を元に、ID・名前・スプライトURLをまとめて返す
+	var pokemons []Pokemon
+
+	// ポケモンのURLからIDを取り出すための正規表現
+	re := regexp.MustCompile(`/pokemon/(\d+)/?$`)
+
+	for _, result := range listResp.Results {
+		matches := re.FindStringSubmatch(result.URL)
+		if len(matches) < 2 {
+			// ID が取れなかった場合はスキップ
+			continue
+		}
+
+		id, err := strconv.Atoi(matches[1])
+		if err != nil {
+			// 数値変換できなければスキップ
+			continue
+		}
+
+		// スプライト画像は PokeAPI が管理している GitHub から直接参照する形で削減
+		imageURL := fmt.Sprintf("https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/%d.png", id)
+
+		pokemons = append(pokemons, Pokemon{
+			ID:    id,
+			Name:  result.Name,
+			Image: imageURL,
+		})
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(pokemon)
+	json.NewEncoder(w).Encode(pokemons)
 }
 
 func main() {
 	r := mux.NewRouter()
-	r.HandleFunc("/pokemon/{id}", getPokemonHandler).Methods("GET")
+
+	// 全ポケモン取得エンドポイント
+	r.HandleFunc("/pokemons", getPokemonsHandler).Methods("GET")
 
 	fmt.Println("サーバー起動: http://localhost:8080")
 	log.Fatal(http.ListenAndServe(":8080", r))

--- a/backend/models.go
+++ b/backend/models.go
@@ -1,0 +1,31 @@
+package main
+
+// Sprites はポケモンの画像情報を表します。
+type Sprites struct {
+	FrontDefault string `json:"front_default"`
+}
+
+// PokemonResponse はポケモンAPIのレスポンスを表します。
+type PokemonResponse struct {
+	ID      int     `json:"id"`
+	Name    string  `json:"name"`
+	Sprites Sprites `json:"sprites"`
+}
+
+// Pokemon はフロントエンド向けのデータ構造（単体用・複数用で共通利用）。
+type Pokemon struct {
+	ID    int    `json:"id"`
+	Name  string `json:"name"`
+	Image string `json:"image"`
+}
+
+// PokemonListResponse は /pokemon?limit=... 取得時のレスポンスを表します。
+type PokemonListResponse struct {
+	Count    int    `json:"count"`
+	Next     string `json:"next"`
+	Previous string `json:"previous"`
+	Results  []struct {
+		Name string `json:"name"`
+		URL  string `json:"url"`
+	} `json:"results"`
+}


### PR DESCRIPTION
## PR 概要
現在の `main.go` では特定のポケモン（ID指定）のみ取得できる状態だったため、  
全ポケモンのデータ（番号・名前・画像）を取得できる API (`GET /pokemons`) を新規追加しました。  
これにより、フロントエンドや他のサービスが **すべてのポケモン情報を一括で取得できるようになります。**

さらにmain.go の分割:を分割してhandlers.go と models.go の作成しました。

## 変更内容
- `GET /pokemons` エンドポイントを実装し、すべてのポケモン情報を取得可能に  
- PokeAPI の **`/pokemon?limit=2000`** からデータを取得し、一覧を返す処理を実装  
- PokeAPI のレスポンスを解析し、各ポケモンの **ID・名前・画像URL** を抽出  
- 取得したデータを **フロントエンド向けに整形して JSON レスポンスを返す**

- main.go の責務を分割し、サーバーの起動処理のみを保持
-  handlers.go を作成し、APIエンドポイント（ハンドラ関数）を移動
-  models.go を作成し、APIレスポンスの構造体定義を移動
-  ルーティング処理 (mux.Router) は main.go に残し、適切にハンドラ関数を呼び出すよう修正

## postmanによる動作確認

### IDを指定する場合
<img width="1437" alt="スクリーンショット 2025-03-12 19 18 19" src="https://github.com/user-attachments/assets/5694a2d5-02ce-4351-9361-b1444215fb94" />

### 前ポケモンのデータを取得する場合
<img width="1436" alt="スクリーンショット 2025-03-12 19 18 43" src="https://github.com/user-attachments/assets/36df637b-1697-4c04-9ff6-62f1955b1d5a" />